### PR TITLE
fix: changes the MedicalServices table

### DIFF
--- a/scripts/fetcher.py
+++ b/scripts/fetcher.py
@@ -22,22 +22,6 @@ DEMAS_URL = "https://apidadosabertos.saude.gov.br/cnes/estabelecimentos/"
 
 DATA_PATH = os.getenv("PYTHONPATH") + "/data/"
 
-
-def __download_data(url: str) -> bytes:
-    """
-    Downloads data from a URL using curl and returns the data in bytes.
-
-    Args:
-    url (str): URL of the file to be downloaded
-
-    Returns:
-    bytes: Downloaded data
-    """
-    result = subprocess.run(['curl', '-s', url],
-                            capture_output=True, check=True)
-    return result.stdout
-
-
 def __save_data(data: bytes, name: str) -> None:
     """
     Saves the data to a file with the desired name in the fetcher folder.
@@ -62,27 +46,6 @@ def __save_data(data: bytes, name: str) -> None:
     except OSError as e:
         print(f"Error saving data to {file_path}: {e}")
         raise
-
-
-def __unzip_cnes_data(date: str) -> None:
-    """
-    Extracts the one desired .csv file in the .zip downloaded from CNES
-
-    Args:
-    date (str): Date of the data to be extracted (YYYYMM)
-
-    Returns:
-    None
-    """
-    zip_path = os.path.join(DATA_PATH, f"BASE_DE_DADOS_CNES_{date}.zip")
-
-    if not os.path.exists(zip_path):
-        raise ValueError(
-            "There isn't any file with the specified name or date.")
-
-    with zipfile.ZipFile(zip_path, 'r') as zip_ref:
-        zip_ref.extract(f"{ESPEC_FILE_NAME}{date}.csv", DATA_PATH)
-
 
 def clean_cache() -> None:
     """

--- a/scripts/populator.py
+++ b/scripts/populator.py
@@ -175,11 +175,11 @@ if __name__ == '__main__':
     
     if args.skip_to <= 3:
         print("[3] Populating service records")
-        #populate_service_records(elasticnes)
+        populate_service_records(elasticnes)
 
     if args.skip_to <= 4:
         print("[4] Populating general info")
-        #populate_general_info(elasticnes)
+        populate_general_info(elasticnes)
 
     if args.skip_to <= 5:
         print("[5] Cleaning cache")

--- a/scripts/populator.py
+++ b/scripts/populator.py
@@ -66,10 +66,11 @@ def populate_general_info(elasticnes: pd.DataFrame) -> None:
     """
     codes = set(elasticnes['CNES'])
     total = len(codes)
-    current = 1
+    current = 0
     startedAt = datetime.now()
 
     for cnes_code in codes:
+        current += 1
         progress_bar(current, total, startedAt, suffix=f"Downloading {cnes_code}")
         while True:
             try:
@@ -80,7 +81,6 @@ def populate_general_info(elasticnes: pd.DataFrame) -> None:
             break
         general_info = process_general_info(elasticnes, f"{DATA_PATH}/{cnes_code}.json")
         populate_db_from_object(general_info)
-        current += 1
         progress_bar(current, total, startedAt, suffix=cnes_code)
 
 def filter_dataframe(elasticnes: pd.DataFrame) -> pd.DataFrame:
@@ -153,25 +153,34 @@ def parse_args() -> argparse.Namespace:
 
     parser.add_argument("--year", type=int, required=True, help="Ano (formato: YYYY)")
     parser.add_argument("--month", type=int, required=True, help="Mês (formato: MM, 1 a 12)")
+    parser.add_argument("--skip-to", type=int, default=0, help="Pula para a etapa desejada")
 
     return parser.parse_args()
 
 if __name__ == '__main__':
     args = parse_args()
 
-    print("[0] Downloading data")
-    #download_cnes_data(args.year, args.month)
+    if args.skip_to <= 0:
+        print("[0] Downloading data")
+        download_cnes_data(args.year, args.month)
 
     # Reads .csv from ELASTICNES to a dataframe
-    print("[1] Reading data from file")
-    elasticnes = pd.read_csv(f"{DATA_PATH}DADOS_CNES.csv")
+    if args.skip_to <= 1:
+        print("[1] Reading data from file")
+        elasticnes = pd.read_csv(f"{DATA_PATH}DADOS_CNES.csv")
 
-    print("[2] Populating medical services")
-    #populate_medical_services(elasticnes)
-    print("[3] Populating service records")
-    #populate_service_records(elasticnes)
-    print("[4] Populating general info")
-    populate_general_info(elasticnes)
+    if args.skip_to <= 2:    
+        print("[2] Populating medical services")
+        populate_medical_services(elasticnes)
+    
+    if args.skip_to <= 3:
+        print("[3] Populating service records")
+        #populate_service_records(elasticnes)
 
-    print("[5] Cleaning cache")
-    clean_cache()
+    if args.skip_to <= 4:
+        print("[4] Populating general info")
+        #populate_general_info(elasticnes)
+
+    if args.skip_to <= 5:
+        print("[5] Cleaning cache")
+        clean_cache()

--- a/src/app.py
+++ b/src/app.py
@@ -41,14 +41,30 @@ async def root():
 @app.get("/especialidades", 
          summary="Lista de especialidades disponíveis", 
          response_description="Lista de especialidades",
-         response_model=list[str],
-         )
+         response_model=list[dict],
+         description="""Retorna a lista de especialidades disponíveis para consulta. 
+         Consiste em uma lista de objetos do tipo `{id: [number, number], name: string}`. Onde `id` é o par de identificadores que identifica o SERVIÇO e o SERVIÇO CLASSIFICAÇÃO.
+         Esses identificadores são utilizados como atributos `id` e `cls`, respectivamente, em uma requisição para a rota `/unidades`.
+         """,
+         responses={
+            200: {
+                "description": "Lista de especialidades disponíveis", 
+                "content": {
+                    "application/json": {
+                        "example": [
+                            {"id": [121, 12], "name": "MAMOGRAFIA"},
+                            {"id": [145, 9], "name": "EXAMES MICROBIOLOGICOS"},
+                        ]
+                    }
+                }
+            }
+        })
 async def especialidades():
     engine = create_engine(DB_URL)
     session = (sessionmaker(bind=engine))()
-    expertises = session.query(MedicalService.name).distinct().all()
+    expertises = session.query(MedicalService).all()
     
-    return [expertise.tuple()[0] for expertise in expertises]
+    return [{"id": [expertise.id, expertise.class_id], "name": expertise.classification} for expertise in expertises]
 
 @app.get("/unidades", 
          summary="Obtém as unidades próximas a um CEP que atendem uma determinada especialidade",

--- a/src/db/tables.py
+++ b/src/db/tables.py
@@ -1,6 +1,7 @@
-from sqlalchemy import Column, ForeignKey, Integer, String, Float
+from sqlalchemy import Column, Integer, String, Float
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from sqlalchemy.schema import ForeignKeyConstraint
 
 Base=declarative_base()
 
@@ -46,13 +47,17 @@ class MedicalService(Base):
     """MedicalService for a type of service.
 
     Args:
-        id (Integer): Medical service id
-        name (String): Description of the medical expertise
+        id (Integer): ID 'SERVIÇO' from the CNES API
+        class_id (Integer): ID 'SERVIÇO CLASSIFICAÇÃO' from the CNES API
+        service (String): 'SERVIÇO' description
+        classification (String): 'SERVIÇO CLASSIFICAÇÃO' description
     """
     __tablename__='medical_services'
 
     id=Column(Integer, primary_key=True)
-    name=Column(String)
+    class_id=Column(Integer, primary_key=True)
+    service=Column(String)
+    classification=Column(String)
 
 class ServiceRecord(Base):
     """ServiceRecord for a given CNES.
@@ -67,8 +72,11 @@ class ServiceRecord(Base):
     
     id=Column(Integer, primary_key=True, autoincrement=True)
     cnes=Column(Integer)
-    service=Column(Integer, ForeignKey('medical_services.id'))
+    service=Column(Integer)
     #description=Column(String)
-    classification=Column(String)
+    classification=Column(Integer)
     
+    __table_args__=(
+        ForeignKeyConstraint(['service', 'classification'], ['medical_services.id', 'medical_services.class_id']),
+    )
     medical_service=relationship("MedicalService")


### PR DESCRIPTION
This commit changes the MedicalServices table to store: service, service classfication, service id and service classification id

The pair service id and service classification id are the composite primary key for this table

The service classification is returned by the api as the name for a given medical service

We need to change the `/unidades` route to use those 2 id numbers rather than the old `esp` identifier @th-duvanel 