### PR TITLE
feat: add populator container

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -44,5 +44,19 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  populator:
+    build:
+      context: .
+    depends_on:
+      - db
+    environment:
+      - POSTGRES_HOST=db
+      - POSTGRES_DB=${DBNAME}
+      - POSTGRES_USER=${DBUSER}
+      - POSTGRES_PASSWORD=${DBPASS}
+      - PYTHONPATH=${PYTHONPATH}
+    entrypoint: ["python", "scripts/populator.py", "--year", "2024", "--month", "09"]
+    profiles: ["prod", "dev"]
+
 volumes:
   pgdata:

--- a/scripts/populator.py
+++ b/scripts/populator.py
@@ -41,6 +41,12 @@ session = SessionLocal()
 # If tabelas doesn't exist, creates it
 Base.metadata.create_all(bind=engine)
 
+def db_is_populated() -> bool:
+    exists = session.query(GeneralInfo).first() is not None
+    if exists:
+        return True
+    return False
+
 def populate_db_from_object(obj: object) -> None:
     """
     Populates the database with the object passed as argument.
@@ -160,6 +166,10 @@ def parse_args() -> argparse.Namespace:
 if __name__ == '__main__':
     args = parse_args()
 
+    if db_is_populated():
+        print("Database already populated. Skipping population.")
+        exit(0)
+
     if args.skip_to <= 0:
         print("[0] Downloading data")
         download_cnes_data(args.year, args.month)
@@ -169,10 +179,10 @@ if __name__ == '__main__':
         print("[1] Reading data from file")
         elasticnes = pd.read_csv(f"{DATA_PATH}DADOS_CNES.csv")
 
-    if args.skip_to <= 2:    
+    if args.skip_to <= 2:
         print("[2] Populating medical services")
         populate_medical_services(elasticnes)
-    
+
     if args.skip_to <= 3:
         print("[3] Populating service records")
         populate_service_records(elasticnes)


### PR DESCRIPTION
Esse PR adiciona um container para rodar o script de popular o banco (populator.py).

O script populator.py apenas rodará de fato quando o banco já não estiver populado, isto é, quando está sendo iniciado pela primeira vez. 

É checado que o banco não está populado no script populator.py, com a função criada a seguir: 

```python
def db_is_populated() -> bool:
    exists = session.query(GeneralInfo).first() is not None
    if exists:
        return True
    return False
```

OBS: O container que roda o comando é terminado ao finalizar de executar o script.